### PR TITLE
Docker windows

### DIFF
--- a/docker.md
+++ b/docker.md
@@ -9,6 +9,7 @@ title:  Stanford AHA
 <https://docs.docker.com/guides/docker-overview/>
 
 # Install Docker
+(This section is for linux machines; for MacOS and Windows installations, scroll down and see `MacOS and Windows` section below.)
 
 ```
 sudo systemctl start docker

--- a/docker.md
+++ b/docker.md
@@ -5,11 +5,15 @@ title:  Stanford AHA
 ---
 # Using Docker to Run the AHA Flow
 
+The docker overview can tell you about what is docker and how to install it on your machine.
+
 [Docker Overview](https://docs.docker.com/guides/docker-overview/) :: 
 <https://docs.docker.com/guides/docker-overview/>
 
+[Installing Docker](https://docs.docker.com/get-started/get-docker) ::
+<https://docs.docker.com/get-started/get-docker>
+
 # Install Docker
-(This section is for linux machines; for MacOS and Windows installations, scroll down and see `MacOS and Windows` section below.)
 
 ```
 sudo systemctl start docker


### PR DESCRIPTION
I was able to get docker running on windows with very little problem. On my wimpy machine, it took awhile, maybe 20-30 minutes ish from initial download to aha-prompt-inside-container. (The installation required a windows reboot(!)).

I added a line or two to the docker instructions to reflect what I actually had to do, and I thought people ( @kalhankoul96 ) might want to review and/or improve, thus this pull request.